### PR TITLE
Introduce MQTT auto discovery for Home Assistant

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env: 
+  RELEASE: 3.0
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -25,6 +28,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/386,linux/amd64
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: rpearce/sofar2mqtt-python:latest
+          tags: rpearce/sofar2mqtt-python:${RELEASE}-${GITHUB_SHA}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,6 +8,7 @@ on:
 
 env: 
   RELEASE: 3.0
+  IMAGE_NAME: ${{ github.repository }} 
 
 jobs:
   docker:
@@ -30,4 +31,4 @@ jobs:
           context: .
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: rpearce/sofar2mqtt-python:${RELEASE}-${GITHUB_SHA}
+          tags: rpearce/sofar2mqtt-python:${{ env.RELEASE }}-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM python:3.9.18-slim-bullseye
+FROM --platform=$BUILDPLATFORM python:3.12.2-slim-bullseye
 
 WORKDIR /opt/sofar2mqtt
 

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -6,10 +6,7 @@
 			"read_type": "string",
 			"registers": 7,
 			"icon": "mdi:information",
-			"state_topic": "sofar/state_all",
-			"enabled_by_default": "true",
 			"entity_category": "diagnostic",
-			"availability_mode": "all",
 			"value_template": "{{ value_json.serial_number }}"
 		},
 		{
@@ -18,10 +15,7 @@
 			"read_type": "string",
 			"registers": 2,
 			"icon": "mdi:information",
-			"state_topic": "sofar/state_all",
-			"enabled_by_default": "true",
 			"entity_category": "diagnostic",
-			"availability_mode": "all",
 			"value_template": "{{ value_json.hw_version }}"
 		},
 		{
@@ -30,10 +24,7 @@
 			"read_type": "string",
 			"registers": 4,
 			"icon": "mdi:information",
-			"state_topic": "sofar/state_all",
-			"enabled_by_default": "true",
 			"entity_category": "diagnostic",
-			"availability_mode": "all",
 			"value_template": "{{ value_json.sw_version_com }}"
 		},
 		{
@@ -42,10 +33,7 @@
 			"read_type": "string",
 			"registers": 4,
 			"icon": "mdi:information",
-			"state_topic": "sofar/state_all",
-			"enabled_by_default": "true",
 			"entity_category": "diagnostic",
-			"availability_mode": "all",
 			"value_template": "{{ value_json.sw_version_master }}"
 		},
 		{
@@ -54,10 +42,7 @@
 			"read_type": "string",
 			"registers": 4,
 			"icon": "mdi:information",
-			"state_topic": "sofar/state_all",
-			"enabled_by_default": "true",
 			"entity_category": "diagnostic",
-			"availability_mode": "all",
 			"value_template": "{{ value_json.sw_version_slave }}"
 		},
 		{
@@ -75,7 +60,6 @@
 			},
 			"write": true,
 			"ha": {
-				"availability_mode": "all",
 				"command_topic": "sofar/rw/energy_storage_mode",
 				"entity_category": "config",
 				"name": "Mode",
@@ -86,7 +70,6 @@
 					"Passive mode",
 					"Peak cut mode"
 				],
-				"state_topic": "sofar/state_all",
 				"value_template": "{{ value_json.energy_storage_mode }}",
 				"icon": "mdi:home-switch",
 				"control": "select"
@@ -130,7 +113,6 @@
 			},
 			"ha": {
 				"name": "Sofar:Time of use",
-				"unique_id": "Sofar_time_of_use",
 				"state_class": "measurement",
 				"icon": "mdi:battery-clock-outline"
 			}
@@ -142,7 +124,6 @@
 			"join": ":",
 			"ha": {
 				"name": "Sofar:Time of use - Start time",
-				"unique_id": "Sofar_time_of_use_start_time",
 				"state_class": "measurement",
 				"icon": "mdi:battery-clock-outline"
 			}
@@ -154,7 +135,6 @@
 			"join": ":",
 			"ha": {
 				"name": "Sofar:Time of use - End time",
-				"unique_id": "Sofar_time_of_use_end_time",
 				"state_class": "measurement",
 				"icon": "mdi:battery-clock-outline"
 			}
@@ -169,7 +149,6 @@
 			"write": true,
 			"ha": {
 				"name": "Sofar:Time of use - SOC",
-				"unique_id": "Sofar_time_of_use_soc",
 				"state_class": "measurement",
 				"icon": "mdi:battery-clock-outline"
 			}
@@ -180,7 +159,6 @@
 			"read_type": "long",
 			"ha": {
 				"name": "Sofar:Time of use - Power",
-				"unique_id": "Sofar_time_of_use_power",
 				"state_class": "measurement",
 				"icon": "mdi:battery-clock-outline"
 			}
@@ -192,7 +170,6 @@
 			"join": "/",
 			"ha": {
 				"name": "Sofar:Time of use - Start date",
-				"unique_id": "Sofar_time_of_use_start_date",
 				"state_class": "measurement",
 				"icon": "mdi:battery-clock-outline"
 			}
@@ -204,7 +181,6 @@
 			"join": "/",
 			"ha": {
 				"name": "Sofar:Time of use - End date",
-				"unique_id": "Sofar_time_of_use_end_date",
 				"state_class": "measurement",
 				"icon": "mdi:battery-clock-outline"
 			}
@@ -224,7 +200,6 @@
 			],
 			"ha": {
 				"name": "Sofar:Time of use - DoW",
-				"unique_id": "Sofar_time_of_use_dow",
 				"state_class": "measurement",
 				"icon": "mdi:calendar-today-outline"
 			}
@@ -248,7 +223,6 @@
 			],
 			"agg_function": "avg",
 			"ha": {
-				"availability_mode": "all",
 				"command_topic": "sofar/rw/desired_power",
 				"entity_category": "config",
 				"name": "Desired Power",
@@ -257,7 +231,6 @@
 				"step": 50,
 				"initial": 0,
 				"mode": "slider",
-				"state_topic": "sofar/state_all",
 				"value_template": "{{ value_json.desired_power }}",
 				"icon": "mdi:battery-charging",
 				"control": "number"
@@ -297,10 +270,7 @@
 				"name": "State",
 				"icon": "mdi:power-standby",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.state }}"
 			}
 		},
@@ -315,10 +285,7 @@
 				"name": "PV1 Voltage",
 				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.pv_1_voltage }}"
 			}
 		},
@@ -333,10 +300,7 @@
 				"name": "PV1 Current",
 				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.pv_1_current }}"
 			}
 		},
@@ -351,10 +315,7 @@
 				"name": "PV1 Power",
 				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.pv_1_power }}"
 			}
 		},
@@ -369,10 +330,7 @@
 				"name": "PV2 Voltage",
 				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.pv_2_voltage }}"
 			}
 		},
@@ -387,10 +345,7 @@
 				"name": "PV2 Current",
 				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.pv_2_current }}"
 			}
 		},
@@ -405,10 +360,7 @@
 				"name": "PV2 Power",
 				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.pv_2_power }}"
 			}
 		},
@@ -425,10 +377,7 @@
 				"name": "PV Total Power",
 				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.pv_total_power }}"
 			}
 		},
@@ -443,11 +392,8 @@
 				"name": "Active Power",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
 				"unit_of_measurement": "W",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.active_power }}"
 			}
 		},
@@ -461,11 +407,8 @@
 				"name": "Load Power",
 				"icon": "mdi:home-import-outline",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
 				"unit_of_measurement": "W",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.load_power }}"
 			}
 		},
@@ -482,11 +425,8 @@
 				"name": "On-Grid Power",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
 				"unit_of_measurement": "W",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.grid }}"
 			}
 		},
@@ -498,11 +438,8 @@
 				"name": "Insulation Resistance",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
 				"unit_of_measurement": "Ohms",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.insulation_resistance }}"
 			}
 		},
@@ -516,11 +453,8 @@
 				"name": "On-grid Frequency",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
 				"unit_of_measurement": "Hz",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.ongrid_frequency }}"
 			}
 		},
@@ -535,10 +469,7 @@
 				"name": "On-grid Voltage",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.ongrid_voltage }}"
 			}
 		},
@@ -551,10 +482,7 @@
 				"name": "Internal Temperature",
 				"icon": "mdi:thermometer",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.inverter_temp_internal }}"
 			}
 		},
@@ -567,10 +495,7 @@
 				"name": "Heatsink Temperature",
 				"icon": "mdi:thermometer",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.inverter_temp_heatsink }}"
 			}
 		},
@@ -585,10 +510,7 @@
 				"name": "Off-Grid Power",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.offgrid_active_power }}"
 			}
 		},
@@ -603,10 +525,7 @@
 				"name": "Off-Grid Frequency",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.offgrid_frequency }}"
 			}
 		},
@@ -621,10 +540,7 @@
 				"name": "Off-Grid Voltage",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.offgrid_voltage }}"
 			}
 		},
@@ -640,10 +556,7 @@
 				"name": "Battery Current",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.battery_current }}"
 			}
 		},
@@ -659,10 +572,7 @@
 				"name": "Battery Power",
 				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.battery_power }}"
 			}
 		},
@@ -677,10 +587,7 @@
 				"name": "Generation",
 				"icon": "mdi:solar-power",
 				"state_class": "total_increasing",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.today_generation }}"
 			}
 		},
@@ -695,10 +602,7 @@
 				"name": "Consumption",
 				"icon": "mdi:home-import-outline",
 				"state_class": "total_increasing",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.today_consumption }}"
 			}
 		},
@@ -713,10 +617,7 @@
 				"name": "Import",
 				"icon": "mdi:home-import-outline",
 				"state_class": "total_increasing",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.today_import }}"
 			}
 		},
@@ -731,10 +632,7 @@
 				"name": "Export",
 				"icon": "mdi:home-export-outline",
 				"state_class": "total_increasing",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.today_export }}"
 			}
 		},
@@ -749,10 +647,7 @@
 				"name": "Battery Discharge",
 				"icon": "mdi:battery-charging-50",
 				"state_class": "total_increasing",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.today_battery_discharge }}"
 			}
 		},
@@ -767,10 +662,7 @@
 				"name": "Battery Charge",
 				"icon": "mdi:battery-charging",
 				"state_class": "total_increasing",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.today_battery_charge }}"
 			}
 		},
@@ -785,10 +677,7 @@
 				"name": "Battery Voltage",
 				"icon": "mdi:battery-charging-high",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.battery_voltage }}"
 			}
 		},
@@ -802,10 +691,7 @@
 				"name": "Battery Temperature",
 				"icon": "mdi:thermometer",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.battery_voltage }}"
 			}
 		},
@@ -818,10 +704,7 @@
 				"name": "Battery SOC",
 				"icon": "mdi:battery-charging-outline",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.battery_soc }}"
 			}
 		},
@@ -834,10 +717,7 @@
 				"name": "Battery SOH",
 				"icon": "mdi:battery-charging-outline",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.battery_soh }}"
 			}
 		},
@@ -850,10 +730,7 @@
 				"name": "Battery Cycles",
 				"icon": "mdi:battery-clock-outline",
 				"state_class": "measurement",
-				"state_topic": "sofar/state_all",
-				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
-				"availability_mode": "all",
 				"value_template": "{{ value_json.battery_cycles }}"
 			}
 		},

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -4,31 +4,36 @@
 			"name": "serial_number",
 			"register": "0x0445",
 			"read_type": "string",
-			"registers": 7
+			"registers": 7,
+                        "refresh": 86400
 		},
 		{
 			"name": "hw_version",
 			"register": "0x044D",
 			"read_type": "string",
-			"registers": 2
+			"registers": 2,
+                        "refresh": 86400
 		},
 		{
 			"name": "sw_version_com",
 			"register": "0x044F",
 			"read_type": "string",
-			"registers": 4
+			"registers": 4,
+                        "refresh": 86400
 		},
 		{
 			"name": "sw_version_master",
 			"register": "0x0454",
 			"read_type": "string",
-			"registers": 4
+			"registers": 4,
+                        "refresh": 86400
 		},
 		{
 			"name": "sw_version_slave",
 			"register": "0x0457",
 			"read_type": "string",
-			"registers": 4
+			"registers": 4,
+                        "refresh": 86400
 		},
 		{
 			"name": "energy_storage_mode",
@@ -62,31 +67,37 @@
 		},
 		{
 			"name": "charge_start_time",
-			"register": "0x1113"
+			"register": "0x1113",
+                        "refresh": 3600
 		},
 		{
 			"name": "charge_end_time",
-			"register": "0x1114"
+			"register": "0x1114",
+                        "refresh": 3600
 		},
 		{
 			"name": "discharge_start_time",
-			"register": "0x1115"
+			"register": "0x1115",
+                        "refresh": 3600
 		},
 		{
 			"name": "discharge_end_time",
-			"register": "0x1116"
+			"register": "0x1116",
+                        "refresh": 3600
 		},
 		{
 			"name": "charge_power",
 			"register": "0x1117",
 			"function": "multiply",
-			"factor": 10
+			"factor": 10,
+                        "refresh": 3600
 		},
 		{
 			"name": "discharge_power",
 			"register": "0x1118",
 			"function": "multiply",
-			"factor": 10
+			"factor": 10,
+                        "refresh": 3600
 		},
 		{
 			"name": "time_of_use",
@@ -95,19 +106,22 @@
 			"modes": {
 				"0": "Disabled",
 				"1": "Enabled"
-			}
+			},
+                        "refresh": 3600
 		},
 		{
 			"name": "time_of_use_charge_start_time",
 			"register": "0x1122",
 			"function": "high_bit_low_bit",
-			"join": ":"
+			"join": ":",
+                        "refresh": 3600
 		},
 		{
 			"name": "time_of_use_charge_end_time",
 			"register": "0x1123",
 			"function": "high_bit_low_bit",
-			"join": ":"
+			"join": ":",
+                        "refresh": 3600
 		},
 		{
 			"name": "time_of_use_charge_soc",
@@ -116,24 +130,28 @@
 			"function": "int",
 			"min": 30,
 			"max": 100,
-			"write": true
+			"write": true,
+                        "refresh": 3600
 		},
 		{
 			"name": "time_of_use_charge_power",
 			"register": "0x1125",
-			"read_type": "long"
+			"read_type": "long",
+                        "refresh": 3600
 		},
 		{
 			"name": "time_of_use_start_date",
 			"register": "0x1127",
 			"function": "high_bit_low_bit",
-			"join": "/"
+			"join": "/",
+                        "refresh": 3600
 		},
 		{
 			"name": "time_of_use_end_date",
 			"register": "0x1128",
 			"function": "high_bit_low_bit",
-			"join": "/"
+			"join": "/",
+                        "refresh": 3600
 		},
 		{
 			"name": "time_of_use_dow",
@@ -147,7 +165,8 @@
 				"Wed",
 				"Tue",
 				"Mon"
-			]
+			],
+                        "refresh": 3600
 		},
 		{
 			"name": "desired_power",
@@ -187,7 +206,8 @@
 			"desc": "Minimum battery power in passive mode(-999999 to 999999) in watts",
 			"desc2": "Positive value=Charging, Negative value=Discharging",
 			"signed": true,
-			"read_type": "long"
+			"read_type": "long",
+                        "refresh": 3600
 		},
 		{
 			"name": "maximum_battery_power",
@@ -195,7 +215,8 @@
 			"desc": "Maximum battery power in passive mode(-999999 to 999999) in watts",
 			"desc2": "Positive value=Charging, Negative value=Discharging",
 			"signed": true,
-			"read_type": "long"
+			"read_type": "long",
+                        "refresh": 3600
 		},
 		{
 			"name": "state",
@@ -376,7 +397,8 @@
 		},
 		{
 			"name": "insulation_resistance",
-			"register": "0x042B"
+			"register": "0x042B",
+                        "refresh": 3600
 		},
 		{
 			"name": "ongrid_frequency",
@@ -391,7 +413,8 @@
 				"unit_of_measurement": "Hz",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.ongrid_frequency }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "ongrid_voltage",
@@ -406,7 +429,8 @@
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.ongrid_voltage }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "inverter_temp_internal",
@@ -462,7 +486,8 @@
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.offgrid_frequency }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "offgrid_voltage",
@@ -477,7 +502,8 @@
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.offgrid_voltage }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "battery_current",
@@ -524,7 +550,8 @@
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.solar_generation_today }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "today_consumption",
@@ -539,7 +566,8 @@
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.today_consumption }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "today_import",
@@ -554,7 +582,8 @@
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.import_today }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "today_export",
@@ -569,7 +598,8 @@
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.export_today }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "today_battery_discharge",
@@ -584,7 +614,8 @@
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_discharge_today }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "today_battery_charge",
@@ -599,7 +630,8 @@
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_charge_today }}"
-			}
+			},
+                        "refresh": 60
 		},
 		{
 			"name": "battery_voltage",
@@ -654,7 +686,8 @@
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_soh }}"
-			}
+			},
+                        "refresh": 3600
 		},
 		{
 			"name": "battery_cycles",
@@ -667,7 +700,8 @@
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_cycles }}"
-			}
+			},
+                        "refresh": 3600
 		},
 		{
 			"name": "eps_control",
@@ -680,7 +714,8 @@
 				"1": "On"
 			},
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "remote_on_off_control",
@@ -693,7 +728,8 @@
 				"1": "On"
 			},
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "power_control",
@@ -703,7 +739,8 @@
 			"min": 0,
 			"max": 100,
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "active_power_export_limit",
@@ -713,7 +750,8 @@
 			"min": 0,
 			"max": 100,
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "active_power_import_limit",
@@ -723,7 +761,8 @@
 			"min": 0,
 			"max": 100,
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "reactive_power_setting",
@@ -734,7 +773,8 @@
 			"max": 100,
 			"signed": true,
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "power_factor_setting",
@@ -745,7 +785,8 @@
 			"max": 1.0,
 			"signed": true,
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "active_power_limit_speed",
@@ -756,7 +797,8 @@
 			"max": 3000,
 			"signed": true,
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "reactive_power_response_time",
@@ -767,7 +809,8 @@
 			"max": 600,
 			"signed": true,
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "passive_timeout",
@@ -776,7 +819,8 @@
 			"desc2": "When the inverter does not receive any communication frame within time set in this register the inverter forces Passive_Timeout_Action",
 			"type": "U16",
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "passive_timeout_action",
@@ -789,7 +833,8 @@
 				"1": "Force to last storage mode"
 			},
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		},
 		{
 			"name": "desired_power_grid",
@@ -803,7 +848,8 @@
 			"min": -999999,
 			"max": 999999,
 			"write": true,
-			"untested": true
+			"untested": true,
+                        "refresh": 86400
 		}
 	]
 }

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -1,6 +1,66 @@
 {
 	"registers": [
 		{
+			"name": "serial_number",
+			"register": "0x0445",
+			"type": "string",
+			"registers": 7,
+			"icon": "mdi:information",
+			"state_topic": "sofar/state_all",
+			"enabled_by_default": "true",
+			"entity_category": "diagnostic",
+			"availability_mode": "all",
+			"value_template": "{{ value_json.serial_number }}"
+		},
+		{
+			"name": "hw_version",
+			"register": "0x044D",
+			"type": "string",
+			"registers": 2,
+			"icon": "mdi:information",
+			"state_topic": "sofar/state_all",
+			"enabled_by_default": "true",
+			"entity_category": "diagnostic",
+			"availability_mode": "all",
+			"value_template": "{{ value_json.hw_version }}"
+		},
+		{
+			"name": "sw_version_com",
+			"register": "0x044F",
+			"type": "string",
+			"registers": 4,
+			"icon": "mdi:information",
+			"state_topic": "sofar/state_all",
+			"enabled_by_default": "true",
+			"entity_category": "diagnostic",
+			"availability_mode": "all",
+			"value_template": "{{ value_json.sw_version_com }}"
+		},
+		{
+			"name": "sw_version_master",
+			"register": "0x0454",
+			"type": "string",
+			"registers": 4,
+			"icon": "mdi:information",
+			"state_topic": "sofar/state_all",
+			"enabled_by_default": "true",
+			"entity_category": "diagnostic",
+			"availability_mode": "all",
+			"value_template": "{{ value_json.sw_version_master }}"
+		},
+		{
+			"name": "sw_version_slave",
+			"register": "0x0457",
+			"type": "string",
+			"registers": 4,
+			"icon": "mdi:information",
+			"state_topic": "sofar/state_all",
+			"enabled_by_default": "true",
+			"entity_category": "diagnostic",
+			"availability_mode": "all",
+			"value_template": "{{ value_json.sw_version_slave }}"
+		},
+		{
 			"name": "eps_control",
 			"register": "0x1029",
 			"desc": "EPS On/Off control",
@@ -318,8 +378,8 @@
 				"command_topic": "sofar/rw/desired_power",
 				"entity_category": "config",
 				"name": "Desired Power",
-				"min": -6000,
-				"max": 6000,
+				"min": -5000,
+				"max": 5000,
 				"step": 50,
 				"initial": 0,
 				"mode": "slider",
@@ -373,10 +433,14 @@
 				"7": "Self-charging"
 			},
 			"ha": {
-				"name": "Sofar:Inverter state",
-				"unique_id": "Sofar_inverter_state",
+				"name": "State",
+				"icon": "mdi:power-standby",
 				"state_class": "measurement",
-				"icon": "mdi:power-standby"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.state }}"
 			}
 		},
 		{
@@ -385,12 +449,16 @@
 			"function": "divide",
 			"factor": 10,
 			"ha": {
-				"name": "Sofar:Solar PV1 voltage now",
-				"unique_id": "sofar_pv1_voltage_now",
-				"device_class": "power",
+				"device_class": "voltage",
 				"unit_of_measurement": "V",
+				"name": "PV1 Voltage",
+				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"icon": "mdi:solar-power-variant"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.pv_1_voltage }}"
 			}
 		},
 		{
@@ -399,12 +467,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Solar PV1 current now",
-				"unique_id": "sofar_pv1_current_now",
 				"device_class": "current",
 				"unit_of_measurement": "A",
+				"name": "PV1 Current",
+				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"icon": "mdi:solar-power-variant"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.pv_1_current }}"
 			}
 		},
 		{
@@ -413,12 +485,16 @@
 			"function": "multiply",
 			"factor": 10,
 			"ha": {
-				"name": "Sofar:Solar PV1 power now",
-				"unique_id": "sofar_pv1_power_now",
 				"device_class": "power",
 				"unit_of_measurement": "W",
+				"name": "PV1 Power",
+				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"icon": "mdi:solar-power-variant"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.pv_1_power }}"
 			}
 		},
 		{
@@ -427,12 +503,16 @@
 			"function": "divide",
 			"factor": 10,
 			"ha": {
-				"name": "Sofar:Solar PV2 voltage now",
-				"unique_id": "sofar_pv2_voltage_now",
 				"device_class": "voltage",
 				"unit_of_measurement": "V",
+				"name": "PV2 Voltage",
+				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"icon": "mdi:solar-power-variant"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.pv_2_voltage }}"
 			}
 		},
 		{
@@ -441,12 +521,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Solar PV2 current now",
-				"unique_id": "sofar_pv2_current_now",
 				"device_class": "current",
 				"unit_of_measurement": "A",
+				"name": "PV2 Current",
+				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"icon": "mdi:solar-power-variant"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.pv_2_current }}"
 			}
 		},
 		{
@@ -455,12 +539,16 @@
 			"function": "multiply",
 			"factor": 10,
 			"ha": {
-				"name": "Sofar:Solar PV2 power now",
-				"unique_id": "sofar_pv2_power_now",
 				"device_class": "power",
 				"unit_of_measurement": "W",
+				"name": "PV2 Power",
+				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"icon": "mdi:solar-power-variant"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.pv_2_power }}"
 			}
 		},
 		{
@@ -472,11 +560,11 @@
 			"agg_function": "add",
 			"ha": {
 				"device_class": "power",
-				"name": "PV Total",
+				"unit_of_measurement": "W",
+				"name": "PV Total Power",
 				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
 				"state_topic": "sofar/state_all",
-				"unit_of_measurement": "W",
 				"enabled_by_default": "true",
 				"entity_category": "diagnostic",
 				"availability_mode": "all",
@@ -490,12 +578,16 @@
 			"factor": 10,
 			"signed": true,
 			"ha": {
-				"name": "Sofar:Active power",
-				"unique_id": "sofar_active_power",
 				"device_class": "power",
-				"unit_of_measurement": "W",
+				"name": "Active Power",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:flash"
+				"state_topic": "sofar/state_all",
+				"unit_of_measurement": "W",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.active_power }}"
 			}
 		},
 		{
@@ -504,12 +596,16 @@
 			"function": "multiply",
 			"factor": 10,
 			"ha": {
-				"name": "Sofar:House consumption now",
-				"unique_id": "sofar_house_consumption_now",
 				"device_class": "power",
-				"unit_of_measurement": "W",
+				"name": "Load Power",
+				"icon": "mdi:home-import-outline",
 				"state_class": "measurement",
-				"icon": "mdi:home-import-outline"
+				"state_topic": "sofar/state_all",
+				"unit_of_measurement": "W",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.load_power }}"
 			}
 		},
 		{
@@ -521,24 +617,32 @@
 			"agg_function": "subtract",
 			"invert": true,
 			"ha": {
-				"name": "Sofar:Grid power",
-				"unique_id": "sofar_grid_power",
 				"device_class": "power",
-				"unit_of_measurement": "W",
+				"name": "On-Grid Power",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:flash"
+				"state_topic": "sofar/state_all",
+				"unit_of_measurement": "W",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.grid }}"
 			}
 		},
 		{
 			"name": "insulation_resistance",
 			"register": "0x042B",
 			"ha": {
-				"name": "Sofar:Insulation Resistance",
-				"unique_id": "sofar_insulation_resistance",
 				"device_class": "energy",
-				"unit_of_measurement": "Ohms",
+				"name": "Insulation Resistance",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:flash"
+				"state_topic": "sofar/state_all",
+				"unit_of_measurement": "Ohms",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.insulation_resistance }}"
 			}
 		},
 		{
@@ -547,12 +651,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Ongrid Frequency",
-				"unique_id": "sofar_ongrid_frequency",
 				"device_class": "frequency",
-				"unit_of_measurement": "Hz",
+				"name": "On-grid Frequency",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:flash"
+				"state_topic": "sofar/state_all",
+				"unit_of_measurement": "Hz",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.ongrid_frequency }}"
 			}
 		},
 		{
@@ -561,36 +669,48 @@
 			"function": "divide",
 			"factor": 10,
 			"ha": {
-				"name": "Sofar:Ongrid Voltage",
-				"unique_id": "sofar_ongrid_voltage",
 				"device_class": "voltage",
 				"unit_of_measurement": "V",
+				"name": "On-grid Voltage",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:battery-charging-high"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.ongrid_voltage }}"
 			}
 		},
 		{
 			"name": "inverter_temp_internal",
 			"register": "0x0418",
 			"ha": {
-				"name": "Sofar:Inverter temp internal",
-				"unique_id": "Sofar_inverter_temp_internal",
 				"device_class": "temperature",
 				"unit_of_measurement": "C",
+				"name": "Internal Temperature",
+				"icon": "mdi:thermometer",
 				"state_class": "measurement",
-				"icon": "mdi:thermometer"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.inverter_temp_internal }}"
 			}
 		},
 		{
 			"name": "inverter_temp_heatsink",
 			"register": "0x041A",
 			"ha": {
-				"name": "Sofar:Inverter temp heatsink",
-				"unique_id": "Sofar_inverter_temp_heatsink",
 				"device_class": "temperature",
 				"unit_of_measurement": "C",
+				"name": "Heatsink Temperature",
+				"icon": "mdi:thermometer",
 				"state_class": "measurement",
-				"icon": "mdi:thermometer"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.inverter_temp_heatsink }}"
 			}
 		},
 		{
@@ -599,12 +719,16 @@
 			"function": "multiply",
 			"factor": 10,
 			"ha": {
-				"name": "Sofar:Offgrid Active power",
-				"unique_id": "sofar_offgrid_active_power",
 				"device_class": "power",
 				"unit_of_measurement": "W",
+				"name": "Off-Grid Power",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:flash"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.offgrid_active_power }}"
 			}
 		},
 		{
@@ -613,12 +737,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Offgrid Frequency",
-				"unique_id": "sofar_offgrid_frequency",
 				"device_class": "frequency",
 				"unit_of_measurement": "Hz",
+				"name": "Off-Grid Frequency",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:flash"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.offgrid_frequency }}"
 			}
 		},
 		{
@@ -627,12 +755,16 @@
 			"function": "divide",
 			"factor": 10,
 			"ha": {
-				"name": "Sofar:Offgrid Voltage",
-				"unique_id": "sofar_offgrid_voltage",
 				"device_class": "voltage",
 				"unit_of_measurement": "V",
+				"name": "Off-Grid Voltage",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:battery-charging-high"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.offgrid_voltage }}"
 			}
 		},
 		{
@@ -642,12 +774,16 @@
 			"factor": 100,
 			"signed": true,
 			"ha": {
-				"name": "Sofar:Battery current",
-				"unique_id": "sofar_battery_current_now",
 				"device_class": "current",
 				"unit_of_measurement": "A",
+				"name": "Battery Current",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:battery-charging-50"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.battery_current }}"
 			}
 		},
 		{
@@ -657,12 +793,16 @@
 			"factor": 10,
 			"signed": true,
 			"ha": {
-				"name": "Sofar:Battery power",
-				"unique_id": "sofar_battery_power_now",
 				"device_class": "power",
 				"unit_of_measurement": "W",
+				"name": "Battery Power",
+				"icon": "mdi:flash",
 				"state_class": "measurement",
-				"icon": "mdi:battery-charging-50"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.battery_power }}"
 			}
 		},
 		{
@@ -671,12 +811,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Solar generation",
-				"unique_id": "sofar_solar_generation_today",
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
+				"name": "Generation",
+				"icon": "mdi:solar-power",
 				"state_class": "total_increasing",
-				"icon": "mdi:solar-power"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.today_generation }}"
 			}
 		},
 		{
@@ -685,12 +829,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Consumption",
-				"unique_id": "Sofar_consumption_today",
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
+				"name": "Consumption",
+				"icon": "mdi:home-import-outline",
 				"state_class": "total_increasing",
-				"icon": "mdi:home-import-outline"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.today_consumption }}"
 			}
 		},
 		{
@@ -699,12 +847,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Import",
-				"unique_id": "Sofar_import_today",
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
+				"name": "Import",
+				"icon": "mdi:home-import-outline",
 				"state_class": "total_increasing",
-				"icon": "mdi:home-import-outline"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.today_import }}"
 			}
 		},
 		{
@@ -713,12 +865,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Export",
-				"unique_id": "Sofar_export_today",
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
+				"name": "Export",
+				"icon": "mdi:home-export-outline",
 				"state_class": "total_increasing",
-				"icon": "mdi:home-export-outline"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.today_export }}"
 			}
 		},
 		{
@@ -727,12 +883,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Battery discharge",
-				"unique_id": "sofar_battery_discharge_today",
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
+				"name": "Battery Discharge",
+				"icon": "mdi:battery-charging-50",
 				"state_class": "total_increasing",
-				"icon": "mdi:battery-charging-50"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.today_battery_discharge }}"
 			}
 		},
 		{
@@ -741,12 +901,16 @@
 			"function": "divide",
 			"factor": 100,
 			"ha": {
-				"name": "Sofar:Battery charge",
-				"unique_id": "sofar_battery_charge_today",
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
+				"name": "Battery Charge",
+				"icon": "mdi:battery-charging",
 				"state_class": "total_increasing",
-				"icon": "mdi:battery-charging"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.today_battery_charge }}"
 			}
 		},
 		{
@@ -755,12 +919,16 @@
 			"function": "divide",
 			"factor": 10,
 			"ha": {
-				"name": "Sofar Battery:Voltage",
-				"unique_id": "sofar_battery_voltage",
 				"device_class": "energy",
 				"unit_of_measurement": "V",
+				"name": "Battery Voltage",
+				"icon": "mdi:battery-charging-high",
 				"state_class": "measurement",
-				"icon": "mdi:battery-charging-high"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.battery_voltage }}"
 			}
 		},
 		{
@@ -768,46 +936,64 @@
 			"register": "0x0607",
 			"signed": true,
 			"ha": {
-				"name": "Sofar Battery:Temp",
-				"unique_id": "sofar_battery_temp",
 				"device_class": "temperature",
 				"unit_of_measurement": "C",
+				"name": "Battery Temperature",
+				"icon": "mdi:thermometer",
 				"state_class": "measurement",
-				"icon": "mdi:thermometer"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.battery_voltage }}"
 			}
 		},
 		{
 			"name": "battery_soc",
 			"register": "0x0608",
 			"ha": {
-				"name": "Sofar:Battery SoC",
-				"unique_id": "Sofar_battery_SoC",
 				"device_class": "battery",
 				"unit_of_measurement": "%",
+				"name": "Battery SOC",
+				"icon": "mdi:battery-charging-outline",
 				"state_class": "measurement",
-				"icon": "mdi:battery-charging-outline"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.battery_soc }}"
 			}
 		},
 		{
 			"name": "battery_soh",
 			"register": "0x0609",
 			"ha": {
-				"name": "Sofar:Battery SoH",
-				"unique_id": "Sofar_battery_SoH",
 				"device_class": "battery",
 				"unit_of_measurement": "%",
+				"name": "Battery SOH",
+				"icon": "mdi:battery-charging-outline",
 				"state_class": "measurement",
-				"icon": "mdi:battery-charging-outline"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.battery_soh }}"
 			}
 		},
 		{
 			"name": "battery_cycles",
 			"register": "0x060A",
 			"ha": {
-				"name": "Sofar:Battery cycles",
-				"unique_id": "Sofar_battery_cycles",
+				"device_class": "battery",
+				"unit_of_measurement": "%",
+				"name": "Battery Cycles",
+				"icon": "mdi:battery-clock-outline",
 				"state_class": "measurement",
-				"icon": "mdi:battery-clock-outline"
+				"state_topic": "sofar/state_all",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.battery_cycles }}"
 			}
 		}
 	]

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -4,61 +4,31 @@
 			"name": "serial_number",
 			"register": "0x0445",
 			"read_type": "string",
-			"registers": 7,
-                        "ha": {
-                            "name": "Serial Number",
-                            "icon": "mdi:information",
-                            "entity_category": "diagnostic",
-                            "value_template": "{{ value_json.serial_number }}"
-                        }
+			"registers": 7
 		},
 		{
 			"name": "hw_version",
 			"register": "0x044D",
 			"read_type": "string",
-			"registers": 2,
-                        "ha": {
-			    "name": "Hardware Version",
-                            "icon": "mdi:information",
-                            "entity_category": "diagnostic",
-                            "value_template": "{{ value_json.hw_version }}"
-                        }
+			"registers": 2
 		},
 		{
 			"name": "sw_version_com",
 			"register": "0x044F",
 			"read_type": "string",
-			"registers": 4,
-                        "ha": {
-			    "name": "Software Version COM",
-                            "icon": "mdi:information",
-                            "entity_category": "diagnostic",
-                            "value_template": "{{ value_json.sw_version_com }}"
-                        }
+			"registers": 4
 		},
 		{
 			"name": "sw_version_master",
 			"register": "0x0454",
 			"read_type": "string",
-			"registers": 4,
-                        "ha": {
-			    "name": "Software Version Master",
-                            "icon": "mdi:information",
-                            "entity_category": "diagnostic",
-                            "value_template": "{{ value_json.sw_version_master }}"
-                        }
+			"registers": 4
 		},
 		{
 			"name": "sw_version_slave",
 			"register": "0x0457",
 			"read_type": "string",
-			"registers": 4,
-                        "ha": {
-			    "name": "Software Version Slave",
-                            "icon": "mdi:information",
-                            "entity_category": "diagnostic",
-                            "value_template": "{{ value_json.sw_version_slave }}"
-                        }
+			"registers": 4
 		},
 		{
 			"name": "energy_storage_mode",
@@ -125,31 +95,19 @@
 			"modes": {
 				"0": "Disabled",
 				"1": "Enabled"
-			},
-			"ha": {
-				"name": "Time of use",
-				"icon": "mdi:battery-clock-outline"
 			}
 		},
 		{
 			"name": "time_of_use_charge_start_time",
 			"register": "0x1122",
 			"function": "high_bit_low_bit",
-			"join": ":",
-			"ha": {
-				"name": "Time of use - Start time",
-				"icon": "mdi:battery-clock-outline"
-			}
+			"join": ":"
 		},
 		{
 			"name": "time_of_use_charge_end_time",
 			"register": "0x1123",
 			"function": "high_bit_low_bit",
-			"join": ":",
-			"ha": {
-				"name": "Time of use - End time",
-				"icon": "mdi:battery-clock-outline"
-			}
+			"join": ":"
 		},
 		{
 			"name": "time_of_use_charge_soc",
@@ -158,40 +116,24 @@
 			"function": "int",
 			"min": 30,
 			"max": 100,
-			"write": true,
-			"ha": {
-				"name": "Time of use - SOC",
-				"icon": "mdi:battery-clock-outline"
-			}
+			"write": true
 		},
 		{
 			"name": "time_of_use_charge_power",
 			"register": "0x1125",
-			"read_type": "long",
-			"ha": {
-				"name": "Time of use - Power",
-				"icon": "mdi:battery-clock-outline"
-			}
+			"read_type": "long"
 		},
 		{
 			"name": "time_of_use_start_date",
 			"register": "0x1127",
 			"function": "high_bit_low_bit",
-			"join": "/",
-			"ha": {
-				"name": "Time of use - Start date",
-				"icon": "mdi:battery-clock-outline"
-			}
+			"join": "/"
 		},
 		{
 			"name": "time_of_use_end_date",
 			"register": "0x1128",
 			"function": "high_bit_low_bit",
-			"join": "/",
-			"ha": {
-				"name": "Time of use - End date",
-				"icon": "mdi:battery-clock-outline"
-			}
+			"join": "/"
 		},
 		{
 			"name": "time_of_use_dow",
@@ -205,12 +147,7 @@
 				"Wed",
 				"Tue",
 				"Mon"
-			],
-			"ha": {
-				"name": "Time of use - DoW",
-				"state_class": "measurement",
-				"icon": "mdi:calendar-today-outline"
-			}
+			]
 		},
 		{
 			"name": "desired_power",
@@ -439,16 +376,7 @@
 		},
 		{
 			"name": "insulation_resistance",
-			"register": "0x042B",
-			"ha": {
-				"device_class": "energy",
-				"name": "Insulation Resistance",
-				"icon": "mdi:flash",
-				"state_class": "measurement",
-				"unit_of_measurement": "Ohms",
-				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.insulation_resistance }}"
-			}
+			"register": "0x042B"
 		},
 		{
 			"name": "ongrid_frequency",
@@ -485,7 +413,7 @@
 			"register": "0x0418",
 			"ha": {
 				"device_class": "temperature",
-				"unit_of_measurement": "C",
+				"unit_of_measurement": "°C",
 				"name": "Internal Temperature",
 				"icon": "mdi:thermometer",
 				"state_class": "measurement",
@@ -498,7 +426,7 @@
 			"register": "0x041A",
 			"ha": {
 				"device_class": "temperature",
-				"unit_of_measurement": "C",
+				"unit_of_measurement": "°C",
 				"name": "Heatsink Temperature",
 				"icon": "mdi:thermometer",
 				"state_class": "measurement",
@@ -595,7 +523,7 @@
 				"icon": "mdi:solar-power",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_generation }}"
+				"value_template": "{{ value_json.solar_generation_today }}"
 			}
 		},
 		{
@@ -625,7 +553,7 @@
 				"icon": "mdi:home-import-outline",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_import }}"
+				"value_template": "{{ value_json.import_today }}"
 			}
 		},
 		{
@@ -640,7 +568,7 @@
 				"icon": "mdi:home-export-outline",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_export }}"
+				"value_template": "{{ value_json.export_today }}"
 			}
 		},
 		{
@@ -655,7 +583,7 @@
 				"icon": "mdi:battery-charging-50",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_battery_discharge }}"
+				"value_template": "{{ value_json.battery_discharge_today }}"
 			}
 		},
 		{
@@ -670,7 +598,7 @@
 				"icon": "mdi:battery-charging",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_battery_charge }}"
+				"value_template": "{{ value_json.battery_charge_today }}"
 			}
 		},
 		{
@@ -679,7 +607,7 @@
 			"function": "divide",
 			"factor": 10,
 			"ha": {
-				"device_class": "energy",
+				"device_class": "voltage",
 				"unit_of_measurement": "V",
 				"name": "Battery Voltage",
 				"icon": "mdi:battery-charging-high",
@@ -694,12 +622,12 @@
 			"signed": true,
 			"ha": {
 				"device_class": "temperature",
-				"unit_of_measurement": "C",
+				"unit_of_measurement": "°C",
 				"name": "Battery Temperature",
 				"icon": "mdi:thermometer",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.battery_voltage }}"
+				"value_template": "{{ value_json.battery_temp }}"
 			}
 		},
 		{

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -627,7 +627,7 @@
 			}
 		},
 		{
-			"name": "generation_today",
+			"name": "today_generation",
 			"register": "0x0685",
 			"function": "divide",
 			"factor": 100,
@@ -638,12 +638,12 @@
 				"icon": "mdi:solar-power-variant",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.generation_today }}"
+				"value_template": "{{ value_json.today_generation }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "consumption_today",
+			"name": "today_consumption",
 			"register": "0x0689",
 			"function": "divide",
 			"factor": 100,
@@ -654,12 +654,12 @@
 				"icon": "mdi:home-lightning-bolt-outline",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.consumption_today }}"
+				"value_template": "{{ value_json.today_consumption }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "import_today",
+			"name": "today_import",
 			"register": "0x068D",
 			"function": "divide",
 			"factor": 100,
@@ -670,12 +670,12 @@
 				"icon": "mdi:transmission-tower-import",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.import_today }}"
+				"value_template": "{{ value_json.today_import }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "export_today",
+			"name": "today_export",
 			"register": "0x0691",
 			"function": "divide",
 			"factor": 100,
@@ -686,12 +686,12 @@
 				"icon": "mdi:transmission-tower-export",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.export_today }}"
+				"value_template": "{{ value_json.today_export }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "battery_discharge_today",
+			"name": "today_battery_discharge",
 			"register": "0x0699",
 			"function": "divide",
 			"factor": 100,
@@ -702,12 +702,12 @@
 				"icon": "mdi:battery-minus-variant",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.battery_discharge_today }}"
+				"value_template": "{{ value_json.today_battery_discharge }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "battery_charge_today",
+			"name": "today_battery_charge",
 			"register": "0x0695",
 			"function": "divide",
 			"factor": 100,
@@ -718,7 +718,7 @@
 				"icon": "mdi:battery-plus-variant",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.battery_charge_today }}"
+				"value_template": "{{ value_json.today_battery_charge }}"
 			},
                         "refresh": 60
 		},

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -5,6 +5,12 @@
 			"register": "0x0445",
 			"read_type": "string",
 			"registers": 7,
+			"ha": {
+				"name": "Serial Number",
+				"icon": "mdi:numeric",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.serial_number }}"
+			},
                         "refresh": 86400
 		},
 		{
@@ -12,27 +18,51 @@
 			"register": "0x044D",
 			"read_type": "string",
 			"registers": 2,
+			"ha": {
+				"name": "HW Version",
+				"icon": "mdi:numeric",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.hw_version }}"
+			},
                         "refresh": 86400
 		},
 		{
 			"name": "sw_version_com",
-			"register": "0x044F",
+			"register": "0x0450",
 			"read_type": "string",
-			"registers": 4,
+			"registers": 3,
+			"ha": {
+				"name": "Software Version",
+				"icon": "mdi:numeric",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.sw_version_com }}"
+			},
                         "refresh": 86400
 		},
 		{
 			"name": "sw_version_master",
 			"register": "0x0454",
 			"read_type": "string",
-			"registers": 4,
+			"registers": 3,
+			"ha": {
+				"name": "DSP1 Software Version",
+				"icon": "mdi:numeric",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.sw_version_master }}"
+			},
                         "refresh": 86400
 		},
 		{
 			"name": "sw_version_slave",
-			"register": "0x0457",
+			"register": "0x0458",
 			"read_type": "string",
-			"registers": 4,
+			"registers": 3,
+			"ha": {
+				"name": "DSP2 Software Version",
+				"icon": "mdi:numeric",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.sw_version_slave }}"
+			},
                         "refresh": 86400
 		},
 		{
@@ -107,6 +137,12 @@
 				"0": "Disabled",
 				"1": "Enabled"
 			},
+			"ha": {
+				"name": "Time of use",
+				"icon": "mdi:home-clock",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.time_of_use }}"
+			},
                         "refresh": 3600
 		},
 		{
@@ -114,6 +150,12 @@
 			"register": "0x1122",
 			"function": "high_bit_low_bit",
 			"join": ":",
+			"ha": {
+				"name": "Time of use - Start time",
+				"icon": "mdi:clock-digital",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.time_of_use_charge_start_time }}"
+			},
                         "refresh": 3600
 		},
 		{
@@ -121,6 +163,12 @@
 			"register": "0x1123",
 			"function": "high_bit_low_bit",
 			"join": ":",
+			"ha": {
+				"name": "Time of use - End time",
+				"icon": "mdi:clock-digital",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.time_of_use_charge_end_time }}"
+			},
                         "refresh": 3600
 		},
 		{
@@ -131,12 +179,30 @@
 			"min": 30,
 			"max": 100,
 			"write": true,
+			"ha": {
+				"name": "Time of use - Target SOC",
+				"icon": "mdi:percent-outline",
+				"entity_category": "diagnostic",
+				"device_class": "battery",
+				"unit_of_measurement": "%",
+				"state_class": "measurement",
+				"value_template": "{{ value_json.time_of_use_charge_soc }}"
+			},
                         "refresh": 3600
 		},
 		{
 			"name": "time_of_use_charge_power",
 			"register": "0x1125",
 			"read_type": "long",
+			"ha": {
+				"name": "Time of use - Power",
+				"icon": "mdi:lightning-bolt",
+				"device_class": "power",
+				"unit_of_measurement": "W",
+				"state_class": "measurement",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.time_of_use_charge_power }}"
+			},
                         "refresh": 3600
 		},
 		{
@@ -144,6 +210,12 @@
 			"register": "0x1127",
 			"function": "high_bit_low_bit",
 			"join": "/",
+			"ha": {
+				"name": "Time of use - Start date",
+				"icon": "mdi:calendar",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.time_of_use_start_date }}"
+			},
                         "refresh": 3600
 		},
 		{
@@ -151,6 +223,12 @@
 			"register": "0x1128",
 			"function": "high_bit_low_bit",
 			"join": "/",
+			"ha": {
+				"name": "Time of use - End date",
+				"icon": "mdi:calendar",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.time_of_use_end_date }}"
+			},
                         "refresh": 3600
 		},
 		{
@@ -166,6 +244,12 @@
 				"Tue",
 				"Mon"
 			],
+			"ha": {
+				"name": "Time of use - Days of week",
+				"icon": "mdi:calendar-today",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.time_of_use_dow }}"
+			},
                         "refresh": 3600
 		},
 		{
@@ -396,6 +480,13 @@
 		{
 			"name": "insulation_resistance",
 			"register": "0x042B",
+			"ha": {
+				"name": "Insulation resistance",
+				"icon": "mdi:omega",
+				"unit_of_measurement": "Ohms",
+				"entity_category": "diagnostic",
+				"value_template": "{{ value_json.insulation_resistance }}"
+			},
                         "refresh": 3600
 		},
 		{
@@ -536,98 +627,98 @@
 			}
 		},
 		{
-			"name": "today_generation",
+			"name": "generation_today",
 			"register": "0x0685",
 			"function": "divide",
 			"factor": 100,
 			"ha": {
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
-				"name": "Generation",
+				"name": "Solar Generation Today",
 				"icon": "mdi:solar-power-variant",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_generation }}"
+				"value_template": "{{ value_json.generation_today }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "today_consumption",
+			"name": "consumption_today",
 			"register": "0x0689",
 			"function": "divide",
 			"factor": 100,
 			"ha": {
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
-				"name": "Consumption",
+				"name": "Consumption Today",
 				"icon": "mdi:home-lightning-bolt-outline",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_consumption }}"
+				"value_template": "{{ value_json.consumption_today }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "today_import",
+			"name": "import_today",
 			"register": "0x068D",
 			"function": "divide",
 			"factor": 100,
 			"ha": {
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
-				"name": "Import",
+				"name": "Import Today",
 				"icon": "mdi:transmission-tower-import",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_import }}"
+				"value_template": "{{ value_json.import_today }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "today_export",
+			"name": "export_today",
 			"register": "0x0691",
 			"function": "divide",
 			"factor": 100,
 			"ha": {
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
-				"name": "Export",
+				"name": "Export Today",
 				"icon": "mdi:transmission-tower-export",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_export }}"
+				"value_template": "{{ value_json.export_today }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "today_battery_discharge",
+			"name": "battery_discharge_today",
 			"register": "0x0699",
 			"function": "divide",
 			"factor": 100,
 			"ha": {
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
-				"name": "Battery Discharge",
+				"name": "Battery Discharge Today",
 				"icon": "mdi:battery-minus-variant",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_battery_discharge }}"
+				"value_template": "{{ value_json.battery_discharge_today }}"
 			},
                         "refresh": 60
 		},
 		{
-			"name": "today_battery_charge",
+			"name": "battery_charge_today",
 			"register": "0x0695",
 			"function": "divide",
 			"factor": 100,
 			"ha": {
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
-				"name": "Battery Charge",
+				"name": "Battery Charge Today",
 				"icon": "mdi:battery-plus-variant",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.today_battery_charge }}"
+				"value_template": "{{ value_json.battery_charge_today }}"
 			},
                         "refresh": 60
 		},

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -206,8 +206,7 @@
 			"desc": "Minimum battery power in passive mode(-999999 to 999999) in watts",
 			"desc2": "Positive value=Charging, Negative value=Discharging",
 			"signed": true,
-			"read_type": "long",
-                        "refresh": 3600
+			"read_type": "long"
 		},
 		{
 			"name": "maximum_battery_power",
@@ -215,8 +214,7 @@
 			"desc": "Maximum battery power in passive mode(-999999 to 999999) in watts",
 			"desc2": "Positive value=Charging, Negative value=Discharging",
 			"signed": true,
-			"read_type": "long",
-                        "refresh": 3600
+			"read_type": "long"
 		},
 		{
 			"name": "state",

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -61,106 +61,6 @@
 			"value_template": "{{ value_json.sw_version_slave }}"
 		},
 		{
-			"name": "eps_control",
-			"register": "0x1029",
-			"desc": "EPS On/Off control",
-			"type": "U16",
-			"function": "mode",
-			"modes": {
-				"0": "Off",
-				"1": "On"
-			},
-			"write": true,
-			"untested": true
-		},
-		{
-			"name": "remote_on_off_control",
-			"register": "0x1104",
-			"desc": "Turn inverter on/off",
-			"type": "U16",
-			"function": "mode",
-			"modes": {
-				"0": "Off",
-				"1": "On"
-			},
-			"write": true,
-			"untested": true
-		},
-		{
-			"name": "power_control",
-			"register": "0x1105",
-			"desc": "AC power control settings (0 to 100%)",
-			"type": "U16",
-			"min": 0,
-			"max": 100,
-			"write": true,
-			"untested": true
-		},
-		{
-			"name": "active_power_export_limit",
-			"register": "0x1106",
-			"desc": "AC output active power maximum percentage (0 to 100%)",
-			"type": "U16",
-			"min": 0,
-			"max": 100,
-			"write": true,
-			"untested": true
-		},
-		{
-			"name": "active_power_import_limit",
-			"register": "0x1107",
-			"desc": "AC input active power maximum percentage (0 to 100%)",
-			"type": "U16",
-			"min": 0,
-			"max": 100,
-			"write": true,
-			"untested": true
-		},
-		{
-			"name": "reactive_power_setting",
-			"register": "0x1108",
-			"desc": "AC reactive power percentage (-100 to 100%)",
-			"type": "I16",
-			"min": -100,
-			"max": 100,
-			"signed": true,
-			"write": true,
-			"untested": true
-		},
-		{
-			"name": "power_factor_setting",
-			"register": "0x1109",
-			"desc": "AC power factor (-1.00 to 1.00)",
-			"type": "I16",
-			"min": -1.00,
-			"max": 1.0,
-			"signed": true,
-			"write": true,
-			"untested": true
-		},
-		{
-			"name": "active_power_limit_speed",
-			"register": "0x110a",
-			"desc": "The charge rate of active power (1 to 3000%)",
-			"type": "U16",
-			"min": 1,
-			"max": 3000,
-			"signed": true,
-			"write": true,
-			"untested": true
-		},
-		{
-			"name": "reactive_power_response_time",
-			"register": "0x110b",
-			"desc": "Reactive power response time in secs (0.1 to 600)",
-			"type": "U16",
-			"min": 0.1,
-			"max": 600,
-			"signed": true,
-			"write": true,
-			"untested": true
-		},
-		{
 			"name": "energy_storage_mode",
 			"register": "0x1110",
 			"desc": "Storage mode",
@@ -1004,6 +904,106 @@
 				"availability_mode": "all",
 				"value_template": "{{ value_json.battery_cycles }}"
 			}
-		}
+		},
+		{
+			"name": "eps_control",
+			"register": "0x1029",
+			"desc": "EPS On/Off control",
+			"type": "U16",
+			"function": "mode",
+			"modes": {
+				"0": "Off",
+				"1": "On"
+			},
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "remote_on_off_control",
+			"register": "0x1104",
+			"desc": "Turn inverter on/off",
+			"type": "U16",
+			"function": "mode",
+			"modes": {
+				"0": "Off",
+				"1": "On"
+			},
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "power_control",
+			"register": "0x1105",
+			"desc": "AC power control settings (0 to 100%)",
+			"type": "U16",
+			"min": 0,
+			"max": 100,
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "active_power_export_limit",
+			"register": "0x1106",
+			"desc": "AC output active power maximum percentage (0 to 100%)",
+			"type": "U16",
+			"min": 0,
+			"max": 100,
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "active_power_import_limit",
+			"register": "0x1107",
+			"desc": "AC input active power maximum percentage (0 to 100%)",
+			"type": "U16",
+			"min": 0,
+			"max": 100,
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "reactive_power_setting",
+			"register": "0x1108",
+			"desc": "AC reactive power percentage (-100 to 100%)",
+			"type": "I16",
+			"min": -100,
+			"max": 100,
+			"signed": true,
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "power_factor_setting",
+			"register": "0x1109",
+			"desc": "AC power factor (-1.00 to 1.00)",
+			"type": "I16",
+			"min": -1.00,
+			"max": 1.0,
+			"signed": true,
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "active_power_limit_speed",
+			"register": "0x110a",
+			"desc": "The charge rate of active power (1 to 3000%)",
+			"type": "U16",
+			"min": 1,
+			"max": 3000,
+			"signed": true,
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "reactive_power_response_time",
+			"register": "0x110b",
+			"desc": "Reactive power response time in secs (0.1 to 600)",
+			"type": "U16",
+			"min": 0.1,
+			"max": 600,
+			"signed": true,
+			"write": true,
+			"untested": true
+		},
 	]
 }

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -462,11 +462,11 @@
 		{
 			"name": "grid",
 			"aggregate": [
-				"active_power",
-				"load_power"
+				"load_power",
+				"active_power"
 			],
 			"agg_function": "subtract",
-			"invert": true,
+			"invert": false,
 			"ha": {
 				"device_class": "power",
 				"name": "On-Grid Power",

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -118,9 +118,21 @@
 				"4": "Peak cut mode"
 			},
 			"ha": {
-				"name": "Sofar:Mode",
-				"unique_id": "Sofar_mode",
-				"icon": "mdi:home-battery"
+				"availability_mode": "all",
+				"command_topic": "sofar/rw/energy_storage_mode",
+				"entity_category": "config",
+				"name": "Mode",
+				"options": [
+					"Self use",
+					"Time of use",
+					"Timing mode",
+					"Passive mode",
+					"Peak cut mode"
+				],
+				"state_topic": "sofar/state_all",
+				"value_template": "{{ value_json.energy_storage_mode }}",
+				"icon": "mdi:home-switch",
+				"control": "select"
 			}
 		},
 		{
@@ -294,21 +306,36 @@
 			"write": true
 		},
 		{
-                        "name": "desired_power",
-                        "aggregate": [
-                                "minimum_battery_power",
-                                "maximum_battery_power"
-                        ],
-                        "agg_function": "avg",
-                        "desc": "Reading 0x1189 will always return 0. Min is typically -6000 or the value set to 0x1189. Max is typically +6000 or the value set to 0x1189"
-                },
+			"name": "desired_power",
+			"aggregate": [
+				"minimum_battery_power",
+				"maximum_battery_power"
+			],
+			"agg_function": "avg",
+			"desc": "Reading 0x1189 will always return 0. Min is typically -6000 or the value set to 0x1189. Max is typically +6000 or the value set to 0x1189",
+			"ha": {
+				"availability_mode": "all",
+				"command_topic": "sofar/rw/desired_power",
+				"entity_category": "config",
+				"name": "Desired Power",
+				"min": -6000,
+				"max": 6000,
+				"step": 50,
+				"initial": 0,
+				"mode": "slider",
+				"state_topic": "sofar/state_all",
+				"value_template": "{{ value_json.desired_power }}",
+				"icon": "mdi:battery-charging",
+				"control": "number"
+			}
+		},
 		{
 			"name": "minimum_battery_power",
 			"register": "0x1189",
 			"desc": "Minimum battery power in passive mode(-999999 to 999999) in watts",
 			"desc2": "Positive value=Charging, Negative value=Discharging",
 			"signed": true,
-                        "read_type": "long"
+			"read_type": "long"
 		},
 		{
 			"name": "maximum_battery_power",
@@ -316,7 +343,7 @@
 			"desc": "Maximum battery power in passive mode(-999999 to 999999) in watts",
 			"desc2": "Positive value=Charging, Negative value=Discharging",
 			"signed": true,
-                        "read_type": "long"
+			"read_type": "long"
 		},
 		{
 			"name": "desired_power_grid",
@@ -444,12 +471,16 @@
 			],
 			"agg_function": "add",
 			"ha": {
-				"name": "Sofar:Solar power now",
-				"unique_id": "sofar_solar_power_now",
 				"device_class": "power",
-				"unit_of_measurement": "W",
+				"name": "PV Total",
+				"icon": "mdi:solar-power-variant",
 				"state_class": "measurement",
-				"icon": "mdi:solar-power-variant"
+				"state_topic": "sofar/state_all",
+				"unit_of_measurement": "W",
+				"enabled_by_default": "true",
+				"entity_category": "diagnostic",
+				"availability_mode": "all",
+				"value_template": "{{ value_json.pv_total_power }}"
 			}
 		},
 		{

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -5,45 +5,60 @@
 			"register": "0x0445",
 			"read_type": "string",
 			"registers": 7,
-			"icon": "mdi:information",
-			"entity_category": "diagnostic",
-			"value_template": "{{ value_json.serial_number }}"
+                        "ha": {
+                            "name": "Serial Number",
+                            "icon": "mdi:information",
+                            "entity_category": "diagnostic",
+                            "value_template": "{{ value_json.serial_number }}"
+                        }
 		},
 		{
 			"name": "hw_version",
 			"register": "0x044D",
 			"read_type": "string",
 			"registers": 2,
-			"icon": "mdi:information",
-			"entity_category": "diagnostic",
-			"value_template": "{{ value_json.hw_version }}"
+                        "ha": {
+			    "name": "Hardware Version",
+                            "icon": "mdi:information",
+                            "entity_category": "diagnostic",
+                            "value_template": "{{ value_json.hw_version }}"
+                        }
 		},
 		{
 			"name": "sw_version_com",
 			"register": "0x044F",
 			"read_type": "string",
 			"registers": 4,
-			"icon": "mdi:information",
-			"entity_category": "diagnostic",
-			"value_template": "{{ value_json.sw_version_com }}"
+                        "ha": {
+			    "name": "Software Version COM",
+                            "icon": "mdi:information",
+                            "entity_category": "diagnostic",
+                            "value_template": "{{ value_json.sw_version_com }}"
+                        }
 		},
 		{
 			"name": "sw_version_master",
 			"register": "0x0454",
 			"read_type": "string",
 			"registers": 4,
-			"icon": "mdi:information",
-			"entity_category": "diagnostic",
-			"value_template": "{{ value_json.sw_version_master }}"
+                        "ha": {
+			    "name": "Software Version Master",
+                            "icon": "mdi:information",
+                            "entity_category": "diagnostic",
+                            "value_template": "{{ value_json.sw_version_master }}"
+                        }
 		},
 		{
 			"name": "sw_version_slave",
 			"register": "0x0457",
 			"read_type": "string",
 			"registers": 4,
-			"icon": "mdi:information",
-			"entity_category": "diagnostic",
-			"value_template": "{{ value_json.sw_version_slave }}"
+                        "ha": {
+			    "name": "Software Version Slave",
+                            "icon": "mdi:information",
+                            "entity_category": "diagnostic",
+                            "value_template": "{{ value_json.sw_version_slave }}"
+                        }
 		},
 		{
 			"name": "energy_storage_mode",
@@ -112,8 +127,7 @@
 				"1": "Enabled"
 			},
 			"ha": {
-				"name": "Sofar:Time of use",
-				"state_class": "measurement",
+				"name": "Time of use",
 				"icon": "mdi:battery-clock-outline"
 			}
 		},
@@ -123,8 +137,7 @@
 			"function": "high_bit_low_bit",
 			"join": ":",
 			"ha": {
-				"name": "Sofar:Time of use - Start time",
-				"state_class": "measurement",
+				"name": "Time of use - Start time",
 				"icon": "mdi:battery-clock-outline"
 			}
 		},
@@ -134,8 +147,7 @@
 			"function": "high_bit_low_bit",
 			"join": ":",
 			"ha": {
-				"name": "Sofar:Time of use - End time",
-				"state_class": "measurement",
+				"name": "Time of use - End time",
 				"icon": "mdi:battery-clock-outline"
 			}
 		},
@@ -148,8 +160,7 @@
 			"max": 100,
 			"write": true,
 			"ha": {
-				"name": "Sofar:Time of use - SOC",
-				"state_class": "measurement",
+				"name": "Time of use - SOC",
 				"icon": "mdi:battery-clock-outline"
 			}
 		},
@@ -158,8 +169,7 @@
 			"register": "0x1125",
 			"read_type": "long",
 			"ha": {
-				"name": "Sofar:Time of use - Power",
-				"state_class": "measurement",
+				"name": "Time of use - Power",
 				"icon": "mdi:battery-clock-outline"
 			}
 		},
@@ -169,8 +179,7 @@
 			"function": "high_bit_low_bit",
 			"join": "/",
 			"ha": {
-				"name": "Sofar:Time of use - Start date",
-				"state_class": "measurement",
+				"name": "Time of use - Start date",
 				"icon": "mdi:battery-clock-outline"
 			}
 		},
@@ -180,8 +189,7 @@
 			"function": "high_bit_low_bit",
 			"join": "/",
 			"ha": {
-				"name": "Sofar:Time of use - End date",
-				"state_class": "measurement",
+				"name": "Time of use - End date",
 				"icon": "mdi:battery-clock-outline"
 			}
 		},
@@ -199,7 +207,7 @@
 				"Mon"
 			],
 			"ha": {
-				"name": "Sofar:Time of use - DoW",
+				"name": "Time of use - DoW",
 				"state_class": "measurement",
 				"icon": "mdi:calendar-today-outline"
 			}
@@ -269,7 +277,6 @@
 			"ha": {
 				"name": "State",
 				"icon": "mdi:power-standby",
-				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.state }}"
 			}

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -73,19 +73,7 @@
 				"3": "Passive mode",
 				"4": "Peak cut mode"
 			},
-			"write": true
-		},
-		{
-			"name": "energy_storage_mode",
-			"register": "0x1110",
-			"function": "mode",
-			"modes": {
-				"0": "Self use",
-				"1": "Time of use",
-				"2": "Timing mode",
-				"3": "Passive mode",
-				"4": "Peak cut mode"
-			},
+			"write": true,
 			"ha": {
 				"availability_mode": "all",
 				"command_topic": "sofar/rw/energy_storage_mode",
@@ -242,46 +230,23 @@
 			}
 		},
 		{
-			"name": "passive_timeout",
-			"register": "0x1184",
-			"desc": "Passive mode timeout period in secs (0=Never)",
-			"desc2": "When the inverter does not receive any communication frame within time set in this register the inverter forces Passive_Timeout_Action",
-			"type": "U16",
-			"write": true
-		},
-		{
-			"name": "passive_timeout_action",
-			"register": "0x1185",
-			"desc": "Passive mode timeout action",
-			"function": "mode",
-			"type": "U16",
-			"modes": {
-				"0": "Force to standby",
-				"1": "Force to last storage mode"
-			},
-			"write": true
-		},
-		{
 			"name": "desired_power",
 			"register": "0x1187",
 			"desc": "Desired PCC power in passive mode(-999999 to 999999) in watts",
 			"desc2": "Positive value=Export, Negative value=Import",
+			"desc3": "Reading 0x1189 will always return 0. Min is typically -6000 or the value set to 0x1189. Max is typically +6000 or the value set to 0x1189",
 			"type": "I32",
 			"function": "int",
 			"signed": true,
 			"passive": true,
 			"min": -999999,
 			"max": 999999,
-			"write": true
-		},
-		{
-			"name": "desired_power",
+			"write": true,
 			"aggregate": [
 				"minimum_battery_power",
 				"maximum_battery_power"
 			],
 			"agg_function": "avg",
-			"desc": "Reading 0x1189 will always return 0. Min is typically -6000 or the value set to 0x1189. Max is typically +6000 or the value set to 0x1189",
 			"ha": {
 				"availability_mode": "all",
 				"command_topic": "sofar/rw/desired_power",
@@ -313,19 +278,6 @@
 			"desc2": "Positive value=Charging, Negative value=Discharging",
 			"signed": true,
 			"read_type": "long"
-		},
-		{
-			"name": "desired_power_grid",
-			"register": "0x118D",
-			"desc": "Maximum power to grid in passive mode(-999999 to 999999) in watts",
-			"desc2": "Positive value=Charging, Negative value=Discharging",
-			"type": "I32",
-			"function": "int",
-			"signed": true,
-			"passive": true,
-			"min": -999999,
-			"max": 999999,
-			"write": true
 		},
 		{
 			"name": "state",
@@ -1005,5 +957,41 @@
 			"write": true,
 			"untested": true
 		},
+		{
+			"name": "passive_timeout",
+			"register": "0x1184",
+			"desc": "Passive mode timeout period in secs (0=Never)",
+			"desc2": "When the inverter does not receive any communication frame within time set in this register the inverter forces Passive_Timeout_Action",
+			"type": "U16",
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "passive_timeout_action",
+			"register": "0x1185",
+			"desc": "Passive mode timeout action",
+			"function": "mode",
+			"type": "U16",
+			"modes": {
+				"0": "Force to standby",
+				"1": "Force to last storage mode"
+			},
+			"write": true,
+			"untested": true
+		},
+		{
+			"name": "desired_power_grid",
+			"register": "0x118D",
+			"desc": "Maximum power to grid in passive mode(-999999 to 999999) in watts",
+			"desc2": "Positive value=Charging, Negative value=Discharging",
+			"type": "I32",
+			"function": "int",
+			"signed": true,
+			"passive": true,
+			"min": -999999,
+			"max": 999999,
+			"write": true,
+			"untested": true
+		}
 	]
 }

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -70,7 +70,8 @@
 				"0": "Off",
 				"1": "On"
 			},
-			"write": true
+			"write": true,
+			"untested": true
 		},
 		{
 			"name": "remote_on_off_control",
@@ -82,7 +83,8 @@
 				"0": "Off",
 				"1": "On"
 			},
-			"write": true
+			"write": true,
+			"untested": true
 		},
 		{
 			"name": "power_control",
@@ -91,7 +93,8 @@
 			"type": "U16",
 			"min": 0,
 			"max": 100,
-			"write": true
+			"write": true,
+			"untested": true
 		},
 		{
 			"name": "active_power_export_limit",
@@ -100,7 +103,8 @@
 			"type": "U16",
 			"min": 0,
 			"max": 100,
-			"write": true
+			"write": true,
+			"untested": true
 		},
 		{
 			"name": "active_power_import_limit",
@@ -109,7 +113,8 @@
 			"type": "U16",
 			"min": 0,
 			"max": 100,
-			"write": true
+			"write": true,
+			"untested": true
 		},
 		{
 			"name": "reactive_power_setting",
@@ -119,7 +124,8 @@
 			"min": -100,
 			"max": 100,
 			"signed": true,
-			"write": true
+			"write": true,
+			"untested": true
 		},
 		{
 			"name": "power_factor_setting",
@@ -129,7 +135,8 @@
 			"min": -1.00,
 			"max": 1.0,
 			"signed": true,
-			"write": true
+			"write": true,
+			"untested": true
 		},
 		{
 			"name": "active_power_limit_speed",
@@ -139,7 +146,8 @@
 			"min": 1,
 			"max": 3000,
 			"signed": true,
-			"write": true
+			"write": true,
+			"untested": true
 		},
 		{
 			"name": "reactive_power_response_time",
@@ -149,7 +157,8 @@
 			"min": 0.1,
 			"max": 600,
 			"signed": true,
-			"write": true
+			"write": true,
+			"untested": true
 		},
 		{
 			"name": "energy_storage_mode",

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -61,7 +61,7 @@
 					"Peak cut mode"
 				],
 				"value_template": "{{ value_json.energy_storage_mode }}",
-				"icon": "mdi:home-switch",
+				"icon": "mdi:auto-mode",
 				"control": "select"
 			}
 		},
@@ -246,7 +246,7 @@
 				"device_class": "voltage",
 				"unit_of_measurement": "V",
 				"name": "PV1 Voltage",
-				"icon": "mdi:solar-power-variant",
+				"icon": "mdi:alpha-v-box",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.pv_1_voltage }}"
@@ -261,7 +261,7 @@
 				"device_class": "current",
 				"unit_of_measurement": "A",
 				"name": "PV1 Current",
-				"icon": "mdi:solar-power-variant",
+				"icon": "mdi:alpha-a-box",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.pv_1_current }}"
@@ -276,7 +276,7 @@
 				"device_class": "power",
 				"unit_of_measurement": "W",
 				"name": "PV1 Power",
-				"icon": "mdi:solar-power-variant",
+				"icon": "mdi:solar-power",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.pv_1_power }}"
@@ -291,7 +291,7 @@
 				"device_class": "voltage",
 				"unit_of_measurement": "V",
 				"name": "PV2 Voltage",
-				"icon": "mdi:solar-power-variant",
+				"icon": "mdi:alpha-v-box",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.pv_2_voltage }}"
@@ -306,7 +306,7 @@
 				"device_class": "current",
 				"unit_of_measurement": "A",
 				"name": "PV2 Current",
-				"icon": "mdi:solar-power-variant",
+				"icon": "mdi:alpha-a-box",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.pv_2_current }}"
@@ -321,7 +321,7 @@
 				"device_class": "power",
 				"unit_of_measurement": "W",
 				"name": "PV2 Power",
-				"icon": "mdi:solar-power-variant",
+				"icon": "mdi:solar-power",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.pv_2_power }}"
@@ -338,7 +338,7 @@
 				"device_class": "power",
 				"unit_of_measurement": "W",
 				"name": "PV Total Power",
-				"icon": "mdi:solar-power-variant",
+				"icon": "mdi:solar-power",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.pv_total_power }}"
@@ -353,7 +353,7 @@
 			"ha": {
 				"device_class": "power",
 				"name": "Active Power",
-				"icon": "mdi:flash",
+				"icon": "mdi:lightning-bolt",
 				"state_class": "measurement",
 				"unit_of_measurement": "W",
 				"entity_category": "diagnostic",
@@ -368,7 +368,7 @@
 			"ha": {
 				"device_class": "power",
 				"name": "Load Power",
-				"icon": "mdi:home-import-outline",
+				"icon": "mdi:home-lightning-bolt-outline",
 				"state_class": "measurement",
 				"unit_of_measurement": "W",
 				"entity_category": "diagnostic",
@@ -386,7 +386,7 @@
 			"ha": {
 				"device_class": "power",
 				"name": "On-Grid Power",
-				"icon": "mdi:flash",
+				"icon": "mdi:lightning-bolt",
 				"state_class": "measurement",
 				"unit_of_measurement": "W",
 				"entity_category": "diagnostic",
@@ -406,7 +406,7 @@
 			"ha": {
 				"device_class": "frequency",
 				"name": "On-grid Frequency",
-				"icon": "mdi:flash",
+				"icon": "mdi:sine-wave",
 				"state_class": "measurement",
 				"unit_of_measurement": "Hz",
 				"entity_category": "diagnostic",
@@ -423,7 +423,7 @@
 				"device_class": "voltage",
 				"unit_of_measurement": "V",
 				"name": "On-grid Voltage",
-				"icon": "mdi:flash",
+				"icon": "mdi:alpha-v-box",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.ongrid_voltage }}"
@@ -437,7 +437,7 @@
 				"device_class": "temperature",
 				"unit_of_measurement": "°C",
 				"name": "Internal Temperature",
-				"icon": "mdi:thermometer",
+				"icon": "mdi:temperature-celsius",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.inverter_temp_internal }}"
@@ -450,7 +450,7 @@
 				"device_class": "temperature",
 				"unit_of_measurement": "°C",
 				"name": "Heatsink Temperature",
-				"icon": "mdi:thermometer",
+				"icon": "mdi:temperature-celsius",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.inverter_temp_heatsink }}"
@@ -465,7 +465,7 @@
 				"device_class": "power",
 				"unit_of_measurement": "W",
 				"name": "Off-Grid Power",
-				"icon": "mdi:flash",
+				"icon": "mdi:lightning-bolt",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.offgrid_active_power }}"
@@ -480,7 +480,7 @@
 				"device_class": "frequency",
 				"unit_of_measurement": "Hz",
 				"name": "Off-Grid Frequency",
-				"icon": "mdi:flash",
+				"icon": "mdi:sine-wave",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.offgrid_frequency }}"
@@ -496,7 +496,7 @@
 				"device_class": "voltage",
 				"unit_of_measurement": "V",
 				"name": "Off-Grid Voltage",
-				"icon": "mdi:flash",
+				"icon": "mdi:alpha-v-box",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.offgrid_voltage }}"
@@ -513,7 +513,7 @@
 				"device_class": "current",
 				"unit_of_measurement": "A",
 				"name": "Battery Current",
-				"icon": "mdi:flash",
+				"icon": "mdi:alpha-a-box",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_current }}"
@@ -529,7 +529,7 @@
 				"device_class": "power",
 				"unit_of_measurement": "W",
 				"name": "Battery Power",
-				"icon": "mdi:flash",
+				"icon": "mdi:battery-charging",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_power }}"
@@ -544,7 +544,7 @@
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
 				"name": "Generation",
-				"icon": "mdi:solar-power",
+				"icon": "mdi:solar-power-variant",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.today_generation }}"
@@ -560,7 +560,7 @@
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
 				"name": "Consumption",
-				"icon": "mdi:home-import-outline",
+				"icon": "mdi:home-lightning-bolt-outline",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.today_consumption }}"
@@ -576,7 +576,7 @@
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
 				"name": "Import",
-				"icon": "mdi:home-import-outline",
+				"icon": "mdi:transmission-tower-import",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.today_import }}"
@@ -592,7 +592,7 @@
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
 				"name": "Export",
-				"icon": "mdi:home-export-outline",
+				"icon": "mdi:transmission-tower-export",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.today_export }}"
@@ -608,7 +608,7 @@
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
 				"name": "Battery Discharge",
-				"icon": "mdi:battery-charging-50",
+				"icon": "mdi:battery-minus-variant",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.today_battery_discharge }}"
@@ -624,7 +624,7 @@
 				"device_class": "energy",
 				"unit_of_measurement": "kWh",
 				"name": "Battery Charge",
-				"icon": "mdi:battery-charging",
+				"icon": "mdi:battery-plus-variant",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.today_battery_charge }}"
@@ -640,7 +640,7 @@
 				"device_class": "voltage",
 				"unit_of_measurement": "V",
 				"name": "Battery Voltage",
-				"icon": "mdi:battery-charging-high",
+				"icon": "mdi:alpha-v-box",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_voltage }}"
@@ -654,7 +654,7 @@
 				"device_class": "temperature",
 				"unit_of_measurement": "°C",
 				"name": "Battery Temperature",
-				"icon": "mdi:thermometer",
+				"icon": "mdi:temperature-celsius",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_temp }}"
@@ -667,7 +667,7 @@
 				"device_class": "battery",
 				"unit_of_measurement": "%",
 				"name": "Battery SOC",
-				"icon": "mdi:battery-charging-outline",
+				"icon": "mdi:battery-80",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_soc }}"
@@ -680,7 +680,7 @@
 				"device_class": "battery",
 				"unit_of_measurement": "%",
 				"name": "Battery SOH",
-				"icon": "mdi:battery-charging-outline",
+				"icon": "mdi:battery-heart-variant",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_soh }}"
@@ -694,7 +694,7 @@
 				"device_class": "battery",
 				"unit_of_measurement": "%",
 				"name": "Battery Cycles",
-				"icon": "mdi:battery-clock-outline",
+				"icon": "mdi:battery-sync",
 				"state_class": "measurement",
 				"entity_category": "diagnostic",
 				"value_template": "{{ value_json.battery_cycles }}"

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -3,7 +3,7 @@
 		{
 			"name": "serial_number",
 			"register": "0x0445",
-			"type": "string",
+			"read_type": "string",
 			"registers": 7,
 			"icon": "mdi:information",
 			"state_topic": "sofar/state_all",
@@ -15,7 +15,7 @@
 		{
 			"name": "hw_version",
 			"register": "0x044D",
-			"type": "string",
+			"read_type": "string",
 			"registers": 2,
 			"icon": "mdi:information",
 			"state_topic": "sofar/state_all",
@@ -27,7 +27,7 @@
 		{
 			"name": "sw_version_com",
 			"register": "0x044F",
-			"type": "string",
+			"read_type": "string",
 			"registers": 4,
 			"icon": "mdi:information",
 			"state_topic": "sofar/state_all",
@@ -39,7 +39,7 @@
 		{
 			"name": "sw_version_master",
 			"register": "0x0454",
-			"type": "string",
+			"read_type": "string",
 			"registers": 4,
 			"icon": "mdi:information",
 			"state_topic": "sofar/state_all",
@@ -51,7 +51,7 @@
 		{
 			"name": "sw_version_slave",
 			"register": "0x0457",
-			"type": "string",
+			"read_type": "string",
 			"registers": 4,
 			"icon": "mdi:information",
 			"state_topic": "sofar/state_all",

--- a/sofar-hyd-ep.json
+++ b/sofar-hyd-ep.json
@@ -549,7 +549,7 @@
 				"icon": "mdi:solar-power",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.solar_generation_today }}"
+				"value_template": "{{ value_json.today_generation }}"
 			},
                         "refresh": 60
 		},
@@ -581,7 +581,7 @@
 				"icon": "mdi:home-import-outline",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.import_today }}"
+				"value_template": "{{ value_json.today_import }}"
 			},
                         "refresh": 60
 		},
@@ -597,7 +597,7 @@
 				"icon": "mdi:home-export-outline",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.export_today }}"
+				"value_template": "{{ value_json.today_export }}"
 			},
                         "refresh": 60
 		},
@@ -613,7 +613,7 @@
 				"icon": "mdi:battery-charging-50",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.battery_discharge_today }}"
+				"value_template": "{{ value_json.today_battery_discharge }}"
 			},
                         "refresh": 60
 		},
@@ -629,7 +629,7 @@
 				"icon": "mdi:battery-charging",
 				"state_class": "total_increasing",
 				"entity_category": "diagnostic",
-				"value_template": "{{ value_json.battery_charge_today }}"
+				"value_template": "{{ value_json.today_battery_charge }}"
 			},
                         "refresh": 60
 		},

--- a/sofar2mqtt-v2.py
+++ b/sofar2mqtt-v2.py
@@ -319,7 +319,7 @@ class Sofar():
                     "entity_id": f"sofar_{register['name']}",
                     "enabled_by_default": "true",
                     "device": {
-                        "name": f"Sofar Inverter",
+                        "name": f"Sofar",
                         "sw_version": self.data["sw_version_com"],
                         "hw_version": self.data["hw_version"],
                         "manufacturer": "SOFAR",

--- a/sofar2mqtt-v2.py
+++ b/sofar2mqtt-v2.py
@@ -162,7 +162,6 @@ class Sofar():
             self.instrument.serial.parity = serial.PARITY_NONE
             self.instrument.serial.stopbits = 1
             self.instrument.serial.timeout  = 0.1   # seconds
-            self.instrument.clear_buffers_before_each_transaction = True
             self.instrument.close_port_after_each_call = True
 
     def read_and_publish(self):
@@ -483,7 +482,7 @@ class Sofar():
 @click.option(
     '--refresh-interval',
     envvar='REFRESH_INTERVAL',
-    default=1,
+    default=0.1,
     type=int,
     help='Refresh data every n seconds',
 )

--- a/sofar2mqtt-v2.py
+++ b/sofar2mqtt-v2.py
@@ -306,6 +306,7 @@ class Sofar():
                     "name": register['name'],
                     "state_topic": "sofar/state_all",
                     "unique_id": f"{sn}_{register['name']}",
+                    "entity_id": f"sofar_{register['name']}",
                     "enabled_by_default": "true",
                     "device": {
                         "name": f"Sofar Inverter",

--- a/sofar2mqtt-v2.py
+++ b/sofar2mqtt-v2.py
@@ -189,16 +189,19 @@ class Sofar():
                             value = abs(value)
             else:
                 read_type = 'register'
+                registers = 1
                 if 'read_type' in register:
                     read_type = register['read_type']
+                if 'registers' in register:
+                    registers = register['registers']
                 value = self.read_value(
                         int(register['register'], 16),
                         read_type,
-                        signed
+                        signed,
+                        registers
                 )
             if value is None:
                 continue
-
             else:
                 # Inverter will return maximum 16-bit integer value when data not available (eg. grid usage when grid down)
                 if value == 65535:
@@ -434,7 +437,7 @@ class Sofar():
             else:
                 logging.error('Modbus Write Request: %s failed. Retry exhausted. Retries: %d', register['name'], retries)
 
-    def read_value(self, registeraddress, read_type, signed):
+    def read_value(self, registeraddress, read_type, signed, registers=1):
         """ Read value from register with a retry mechanism """
         with self.mutex:
             value = None
@@ -448,6 +451,9 @@ class Sofar():
                     elif read_type == "long":
                         value = self.instrument.read_long(
                             registeraddress, functioncode=3, signed=True, number_of_registers=2)
+                    elif read_type == "string":
+                        value = self.instrument.read_string(
+                            registeraddress, functioncode=3, number_of_registers=registers)
                 except minimalmodbus.NoResponseError:
                     logging.debug(traceback.format_exc())
                     retry = retry - 1

--- a/sofar2mqtt-v2.py
+++ b/sofar2mqtt-v2.py
@@ -29,9 +29,12 @@ class Sofar():
     def __init__(self, config_file_path, daemon, retry, retry_delay, write_retry, write_retry_delay, refresh_interval, broker, port, username, password, topic, write_topic, log_level, device):
         self.config = load_config(config_file_path)
         self.write_registers = []
+        untested = False
         for register in self.config['registers']:
+            if "untested" in register:
+                untested = register["untested"]
             if "write" in register:
-                if register["write"]:
+                if register["write"] and not untested:
                     self.write_registers.append(register)
         self.daemon = daemon
         self.retry = retry

--- a/sofar2mqtt-v2.py
+++ b/sofar2mqtt-v2.py
@@ -292,7 +292,7 @@ class Sofar():
             logging.info(traceback.format_exc())
         for register in self.config['registers']:
             if 'ha' not in register:
-                next
+                continue
             try:
                 default_payload = {
                     "availability": [
@@ -309,15 +309,15 @@ class Sofar():
                         "identifiers": [f"sofar2mqtt_python_{sn}"],
                     },
                     "state_topic": "sofar/state_all",
-                    "unique_id": f"sofar_{sn}_pv_total_power",
+                    "unique_id": f"sofar_{register['name']}",
                     "enabled_by_default": "true",
                     "availability_mode": "all",
                 }
                 payload = default_payload | register['ha']
-                payload.delete('control')
                 control = 'sensor'
                 if 'control' in register['ha']:
                     control = register['ha']['control']
+                    payload.pop('control')
                 topic = f"homeassistant/{control}/sofar_{register['name']}/config"
                 self.client.publish(topic, json.dumps(payload), retain=False)
             except Exception:


### PR DESCRIPTION
- Implemented MQTT auto discovery for home assistant - no more manual config!
- Added a new refresh option for each register allowing some registers to be read more regularly (fresher) than other that are less important (i.e serial number)
- Added registers for serial number, software version, hardware version. 
- The script now retains a local dict of data which is updated after reading registers for this iteration (based on refresh)
- After an iteration the entire dict (JSON) is sent to a new topic sofar/state_all'
- Added a new option for LEGACY_PUBLISH to continue to send messages individually in addition to sofar/state_all.
- Introduce Signal handling to ensure graceful exit